### PR TITLE
Fix full page widget styling for iPhone 5/6/7/8

### DIFF
--- a/src/styles/full-page.css
+++ b/src/styles/full-page.css
@@ -75,3 +75,9 @@
     line-height: 1.4;
   }
 }
+
+@media (max-height: 600px) {
+  .dcs-full-page__body p {
+    font: normal 2.2rem/2.5rem 'Greve';
+  }
+}


### PR DESCRIPTION
The body text in the full-page widget on iPhone 5/6/7/8 is too big for the screen height. Adding a media query to decrease the size of the font.

@sallynorthmore - can you please review? Is this the right approach to fix this issue?