### PR TITLE
Remove bottom 0

### DIFF
--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -2,7 +2,6 @@
 
 .dcs-footer {
   background-color: var(--green);
-  bottom: 0;
   box-shadow: 0 0 1.6rem rgba(0, 0, 0, 0.2);
   font-family: 'Katwijk Bold';
   left: 0;


### PR DESCRIPTION
this stops the footer getting cropped by the bottom of the window and hiding the button drop-shadow