### PR TITLE
Fix XSS and spoofing issues in widget.js

### DIFF
--- a/static/widget.js
+++ b/static/widget.js
@@ -136,6 +136,7 @@
 
   function receiveMessage(event) {
     if (!event.data.DIGITAL_CLIMATE_STRIKE) return;
+    if (!event.origin.startsWith(iframeHost)) return;
 
     switch (event.data.action) {
       case 'maximize':
@@ -143,6 +144,7 @@
       case 'closeButtonClicked':
         return closeWindow();
       case 'buttonClicked':
+        if (!event.data.linkUrl.startsWith("http")) return;
         return navigateToLink(event.data.linkUrl);
     }
   }


### PR DESCRIPTION
This patch ensures that the message event comes from the iframe and nobody else.
Further it ensures that navigation triggered by message passing actually navigates to another website and does not allow `javascript` URLs which is a Cross-Site-Scripting vulnerabilities.

If you do not take this patch, people who add widget.js to their web page might introduce a security vulnerability.